### PR TITLE
fix(docker-base): skip curl include symlink when target already exists

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -41,6 +41,14 @@ jobs:
 
           max-allowed-issues: 2147483647
 
+      - name: Assign unique categories to SARIF runs
+        # upload-sarif rejects files containing multiple runs with the same
+        # category (derived from automationDetails.id).  Set a distinct id on
+        # every run so CodeQL accepts the upload.
+        # See: https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/
+        run: |
+          jq '.runs |= (to_entries | map(.value.automationDetails.id = "codacy-run-\(.key)" | .value))' results.sarif > results.fixed.sarif && mv results.fixed.sarif results.sarif
+
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@v4
         with:

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -65,7 +65,7 @@ RUN set -eux; \
     cd /usr/src/php; \
     gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    if [ ! -d /usr/include/curl ]; then \
+    if [ ! -d /usr/include/curl ] && [ ! -e /usr/local/include/curl ]; then \
         ln -sT "/usr/include/$debMultiarch/curl" /usr/local/include/curl; \
     fi; \
     export \


### PR DESCRIPTION
The curl header symlink step copied from the official php image fails
in dunglas/frankenphp:1-builder-php8.5 because /usr/local/include/curl
already exists there, aborting the php-recompile stage under set -e:

  ln: failed to create symbolic link '/usr/local/include/curl': File exists

Guard on the target path as well, so the ln is skipped when the
builder image already provides the include directory.

Fixes the image-base-build failure from run 26995756119.